### PR TITLE
Use setup-node v3 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: '22' # Using Node.js 22 as requested
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Downgraded the setup-node action from v4 to v3 in the GitHub Actions workflow. This ensures compatibility or aligns with the specific version requirements of other dependencies or tools in the pipeline. Node.js 22 configuration remains unchanged.