### PR TITLE
Set nodeLinker to node-modules and disable immutable installs

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,5 @@
+enableImmutableInstalls: false
+
+nodeLinker: node-modules
+
 yarnPath: .yarn/releases/yarn-4.7.0.cjs


### PR DESCRIPTION
Updated `.yarnrc.yml` to use `node-modules` linker for better compatibility. Disabled immutable installs to allow modifications in the `node_modules` folder during development. These changes aim to streamline dependency management.