### PR TITLE
Set contents write permission in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   publish-and-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     steps:
       - name: Checkout code


### PR DESCRIPTION
Added 'contents: write' permission under the 'publish-and-update' job to enable necessary actions. This ensures the workflow has sufficient permissions for publishing and updating tasks.